### PR TITLE
Add GitHub Actions workflow to publish compadre to npm on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,62 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+  contents: read
+
+concurrency:
+  group: publish-${{ github.event.release.id }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish package
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      # No registry-url here — avoids writing an auth token into .npmrc before OIDC publish.
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@11.5.1
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify tag matches package version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          TAG_VERSION="${RELEASE_TAG#v}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Release tag ${RELEASE_TAG} (version ${TAG_VERSION}) does not match package.json version ${PKG_VERSION}"
+            exit 1
+          fi
+
+      - name: Test
+        run: npm test
+
+      # Trusted publishing (OIDC): do NOT set NODE_AUTH_TOKEN or NPM_TOKEN secret.
+      # An invalid token in secrets overrides OIDC and causes npm 404 on publish.
+      - name: Configure registry for publish
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Publish to npm
+        run: npm publish --access public --ignore-scripts


### PR DESCRIPTION
Triggers on GitHub Release published, verifies the release tag matches
package.json version, runs tests, then publishes via OIDC trusted publishing
(no NPM_TOKEN secret required).

https://claude.ai/code/session_01528kRU6ASj4458FTSSf22X